### PR TITLE
docs: add per-crate API reference under doc/

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,17 @@ nps-nop  = "1.0.0-alpha.1"
 
 ## Crates
 
-| Crate | Description |
-|-------|-------------|
-| `nps-core` | Frame header, codec (Tier-1 JSON / Tier-2 MsgPack), frame registry, anchor cache, errors |
-| `nps-ncp`  | NCP frame types (`AnchorFrame`, `DiffFrame`, `StreamFrame`, `CapsFrame`, `ErrorFrame`) |
-| `nps-nwp`  | `QueryFrame`, `ActionFrame`; async `NwpClient` over `reqwest` |
-| `nps-nip`  | `Identity` (Ed25519), encrypted key store (AES-256-GCM + PBKDF2), Ident/Trust/Revoke frames |
-| `nps-ndp`  | Announce/Resolve/Graph frames, in-memory registry, signature validator |
-| `nps-nop`  | Task/Delegate/Sync/AlignStream frames, DAG models, async orchestrator client |
-| `nps-sdk`  | Meta-crate: re-exports the six protocol crates under `nps_sdk::{core, ncp, nwp, nip, ndp, nop}` |
+| Crate | Description | Reference |
+|-------|-------------|-----------|
+| `nps-core` | Frame header, codec (Tier-1 JSON / Tier-2 MsgPack), frame registry, anchor cache, errors | [`doc/nps-rust.core.md`](./doc/nps-rust.core.md) |
+| `nps-ncp`  | NCP frame types (`AnchorFrame`, `DiffFrame`, `StreamFrame`, `CapsFrame`, `ErrorFrame`) | [`doc/nps-rust.ncp.md`](./doc/nps-rust.ncp.md) |
+| `nps-nwp`  | `QueryFrame`, `ActionFrame`; async `NwpClient` over `reqwest` | [`doc/nps-rust.nwp.md`](./doc/nps-rust.nwp.md) |
+| `nps-nip`  | `NipIdentity` (Ed25519), encrypted key store (AES-256-GCM + PBKDF2), Ident/Trust/Revoke frames | [`doc/nps-rust.nip.md`](./doc/nps-rust.nip.md) |
+| `nps-ndp`  | Announce/Resolve/Graph frames, in-memory registry, signature validator | [`doc/nps-rust.ndp.md`](./doc/nps-rust.ndp.md) |
+| `nps-nop`  | Task/Delegate/Sync/AlignStream frames, DAG models, async orchestrator client | [`doc/nps-rust.nop.md`](./doc/nps-rust.nop.md) |
+| `nps-sdk`  | Meta-crate: re-exports the six protocol crates under `nps_sdk::{core, ncp, nwp, nip, ndp, nop}` | — |
+
+Full API reference (per-crate class and method docs) lives under [`doc/`](./doc/) — start with [`doc/overview.md`](./doc/overview.md). For a narrative walkthrough see [`doc/sdk-usage.md`](./doc/sdk-usage.md) / [`doc/sdk-usage.cn.md`](./doc/sdk-usage.cn.md).
 
 ## Quick Start
 

--- a/doc/nps-rust.core.md
+++ b/doc/nps-rust.core.md
@@ -1,0 +1,252 @@
+# `nps-core` — Reference
+
+> Spec: [NPS-1 NCP v0.4](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-1-NCP.md)
+
+Foundation crate. Defines the wire header, encoding tiers, a
+registry-validated codec, the anchor-frame cache, and the `NpsError`
+hierarchy.
+
+---
+
+## Table of contents
+
+- [`FrameType`](#frametype)
+- [`EncodingTier`](#encodingtier)
+- [`FrameHeader`](#frameheader)
+- [`FrameDict`](#framedict)
+- [`NpsFrameCodec`](#npsframecodec)
+- [`FrameRegistry`](#frameregistry)
+- [`AnchorFrameCache`](#anchorframecache)
+- [`NpsError` / `NpsResult`](#npserror--npsresult)
+
+---
+
+## `FrameType`
+
+```rust
+#[repr(u8)]
+pub enum FrameType {
+    Anchor      = 0x01,  Diff     = 0x02,  Stream   = 0x03,  Caps       = 0x04,
+    Query       = 0x10,  Action   = 0x11,
+    Ident       = 0x20,  Trust    = 0x21,  Revoke   = 0x22,
+    Announce    = 0x30,  Resolve  = 0x31,  Graph    = 0x32,
+    Task        = 0x40,  Delegate = 0x41,  Sync     = 0x42,  AlignStream = 0x43,
+    Error       = 0xFE,
+}
+
+impl FrameType {
+    pub fn from_u8(v: u8) -> NpsResult<Self>;   // Err(NpsError::Frame) on unknown
+    pub fn as_u8(self) -> u8;
+}
+```
+
+---
+
+## `EncodingTier`
+
+```rust
+pub enum EncodingTier {
+    Json    = 0,
+    MsgPack = 1,
+}
+```
+
+The value is the bit-7 state of the `flags` byte — `MsgPack = 1` sets
+`0x80`, `Json = 0` leaves it clear.
+
+---
+
+## `FrameHeader`
+
+Wire-format header.
+
+```rust
+pub struct FrameHeader {
+    pub frame_type:     FrameType,
+    pub flags:          u8,
+    pub payload_length: u64,
+    pub is_extended:    bool,
+}
+
+impl FrameHeader {
+    pub fn new(frame_type: FrameType, tier: EncodingTier,
+               is_final: bool, payload_length: u64) -> Self;
+
+    pub fn encoding_tier(&self) -> EncodingTier;   // bit 7
+    pub fn is_final(&self)      -> bool;           // bit 6
+    pub fn header_size(&self)   -> usize;          // 4 or 8
+
+    pub fn parse(wire: &[u8])   -> NpsResult<Self>;
+    pub fn to_bytes(&self)      -> Vec<u8>;
+}
+```
+
+### Flags byte
+
+| Bit | Mask   | Meaning |
+|-----|--------|---------|
+| 7   | `0x80` | TIER — `1` = MsgPack, `0` = JSON |
+| 6   | `0x40` | FINAL — last frame in a stream |
+| 0   | `0x01` | EXT — 8-byte extended header |
+
+### Wire layout
+
+```
+Default (EXT=0, 4 bytes):
+  [frame_type][flags][len_hi][len_lo]         — u16 big-endian length
+
+Extended (EXT=1, 8 bytes):
+  [frame_type][flags][0][0][len_b3..len_b0]   — u32 big-endian length
+```
+
+`FrameHeader::new` auto-enables EXT when `payload_length > 0xFFFF`.
+
+---
+
+## `FrameDict`
+
+```rust
+pub type FrameDict = serde_json::Map<String, Value>;
+```
+
+All frames round-trip through `FrameDict`. Helpers:
+
+```rust
+pub fn encode_json   (dict: &FrameDict) -> NpsResult<Vec<u8>>;
+pub fn encode_msgpack(dict: &FrameDict) -> NpsResult<Vec<u8>>;   // rmp_serde::to_vec_named
+pub fn decode_json   (payload: &[u8])   -> NpsResult<FrameDict>;
+pub fn decode_msgpack(payload: &[u8])   -> NpsResult<FrameDict>;
+```
+
+MsgPack encoding uses the **named-field** form (map keys stay as
+strings) — the wire is interoperable with the JSON tier, just smaller.
+
+---
+
+## `NpsFrameCodec`
+
+Registry-validated, tier-switchable codec.
+
+```rust
+pub const DEFAULT_MAX_PAYLOAD: u64 = 10 * 1024 * 1024;   // 10 MiB
+
+pub struct NpsFrameCodec { /* … */ }
+
+impl NpsFrameCodec {
+    pub fn new(registry: FrameRegistry) -> Self;
+    pub fn with_max_payload(self, max_payload: u64) -> Self;   // builder
+
+    pub fn encode(
+        &self,
+        frame_type: FrameType,
+        dict:       &FrameDict,
+        tier:       EncodingTier,
+        is_final:   bool,
+    ) -> NpsResult<Vec<u8>>;
+
+    pub fn decode(&self, wire: &[u8])      -> NpsResult<(FrameType, FrameDict)>;
+    pub fn peek_header(wire: &[u8])        -> NpsResult<FrameHeader>;
+}
+```
+
+- `encode` fails with `NpsError::Codec` if the serialized payload
+  exceeds `max_payload`.
+- `decode` fails with `NpsError::Frame` if the header's frame type is
+  not registered against this codec's `FrameRegistry`.
+- `peek_header` is an associated function (no `&self`) — useful when
+  streaming to know the length before allocating the full frame.
+
+---
+
+## `FrameRegistry`
+
+```rust
+pub struct FrameRegistry { /* … */ }
+
+impl FrameRegistry {
+    pub fn new()           -> Self;             // empty
+    pub fn register(&mut self, ft: FrameType);
+    pub fn is_registered(&self, ft: FrameType) -> bool;
+
+    pub fn create_default() -> Self;            // NCP only (Anchor/Diff/Stream/Caps/Error)
+    pub fn create_full()    -> Self;            // NCP + NWP + NIP + NDP + NOP
+}
+```
+
+`FrameRegistry::default()` returns an **empty** registry — if you use
+`FrameRegistry::default()` with a codec, every `decode` will fail with
+`"unregistered frame type …"`. Prefer `create_default()` or
+`create_full()`.
+
+---
+
+## `AnchorFrameCache`
+
+Thread-safe-by-construction (not `Sync`: use `Arc<Mutex<_>>` for
+shared mutation) anchor-schema cache with lazy TTL expiry.
+
+```rust
+pub struct AnchorFrameCache {
+    pub clock: Box<dyn Fn() -> Instant + Send + Sync>,   // swap in tests
+    // …
+}
+
+impl AnchorFrameCache {
+    pub fn new() -> Self;
+
+    /// SHA-256 of canonical (sorted-key) JSON of `schema`, prefixed `sha256:`.
+    pub fn compute_anchor_id(schema: &Map<String, Value>) -> String;
+
+    pub fn set(&mut self, schema: Map<String, Value>, ttl_secs: u64)
+                 -> NpsResult<String>;                  // → anchor_id
+    pub fn get(&self, anchor_id: &str)          -> Option<&Map<String, Value>>;
+    pub fn get_required(&self, anchor_id: &str) -> NpsResult<&Map<String, Value>>;
+
+    pub fn invalidate(&mut self, anchor_id: &str);
+    pub fn evict_expired(&mut self);
+
+    pub fn len(&self)      -> usize;           // live entries only
+    pub fn is_empty(&self) -> bool;
+}
+```
+
+### Poisoning
+
+`set` returns `NpsError::AnchorPoison` when the same `anchor_id` is
+already cached with a **different** schema (and still live). Re-inserts
+with an identical schema refresh the TTL.
+
+### Lazy expiry
+
+`get` / `get_required` / `len` / `is_empty` filter by `expires > now`
+without mutating the store. Call `evict_expired()` to actually free
+memory.
+
+### Injectable clock
+
+```rust
+use std::time::{Duration, Instant};
+
+let start = Instant::now();
+let mut cache = AnchorFrameCache::new();
+cache.clock = Box::new(move || start + Duration::from_secs(100_000));
+```
+
+---
+
+## `NpsError` / `NpsResult`
+
+```rust
+pub enum NpsError {
+    Frame(String),
+    Codec(String),
+    AnchorNotFound(String),
+    AnchorPoison(String),
+    Identity(String),
+    Io(String),
+}
+
+pub type NpsResult<T> = Result<T, NpsError>;
+```
+
+`NpsError: Clone + Debug + Display + std::error::Error`.

--- a/doc/nps-rust.ncp.md
+++ b/doc/nps-rust.ncp.md
@@ -1,0 +1,165 @@
+# `nps-ncp` — Reference
+
+> Spec: [NPS-1 NCP v0.4](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-1-NCP.md)
+
+The five NCP frame types. Every struct exposes the same trio:
+
+```rust
+pub fn frame_type() -> FrameType;
+pub fn to_dict(&self) -> FrameDict;
+pub fn from_dict(d: &FrameDict) -> NpsResult<Self>;
+```
+
+> **Note — Rust frame shapes.** The Rust NCP structs carry a slightly
+> different field set from the Java / Python / .NET / TS SDKs: the
+> Rust layouts below are authoritative for this crate.
+
+---
+
+## Table of contents
+
+- [`AnchorFrame` (0x01)](#anchorframe-0x01)
+- [`DiffFrame` (0x02)](#diffframe-0x02)
+- [`StreamFrame` (0x03)](#streamframe-0x03)
+- [`CapsFrame` (0x04)](#capsframe-0x04)
+- [`ErrorFrame` (0xFE)](#errorframe-0xfe)
+
+---
+
+## `AnchorFrame` (0x01)
+
+Publishes a schema anchor + TTL.
+
+```rust
+pub struct AnchorFrame {
+    pub anchor_id:   String,
+    pub schema:      serde_json::Map<String, Value>,
+    pub namespace:   Option<String>,
+    pub description: Option<String>,
+    pub node_type:   Option<String>,     // e.g. "memory" | "action" | …
+    pub ttl:         u64,                // seconds; `from_dict` defaults to 3600
+}
+```
+
+`schema` is stored as a free-form map — typically
+`{ "fields": [ { "name": …, "type": … }, … ] }` but any shape that your
+nodes and clients agree on is valid. `from_dict` falls back to `ttl =
+3600` when the field is missing.
+
+To produce the content-addressed `anchor_id` deterministically use
+[`AnchorFrameCache::compute_anchor_id`](./nps-rust.core.md#anchorframecache).
+
+---
+
+## `DiffFrame` (0x02)
+
+Schema evolution between two anchors.
+
+```rust
+pub struct DiffFrame {
+    pub anchor_id:     String,      // old anchor
+    pub new_anchor_id: String,      // new anchor
+    pub patch:         Vec<Value>,  // JSON-Patch-shaped ops (free-form)
+}
+```
+
+`patch` is serialized verbatim — this crate does not validate the ops;
+the receiver is expected to know the patch dialect (NPS-1 §5.2 uses
+RFC 6902-compatible shape).
+
+---
+
+## `StreamFrame` (0x03)
+
+One chunk of a streamed response. Multiple `StreamFrame`s tile out a
+result; the final chunk sets `is_last = true`.
+
+```rust
+pub struct StreamFrame {
+    pub anchor_id: String,
+    pub seq:       u64,
+    pub payload:   Value,     // opaque — any JSON-representable value
+    pub is_last:   bool,
+}
+```
+
+The wire-level `FINAL` flag (bit 6 of the header) is **separate** from
+`is_last`. `is_last` is an in-payload business marker used by
+[`NwpClient::stream`](./nps-rust.nwp.md#nwpclient) to stop iterating.
+
+---
+
+## `CapsFrame` (0x04)
+
+Node capability / response-envelope frame.
+
+```rust
+pub struct CapsFrame {
+    pub node_id:    String,
+    pub caps:       Vec<String>,         // capability URIs
+    pub anchor_ref: Option<String>,      // anchor being answered against
+    pub payload:    Option<Value>,       // opaque response data
+}
+```
+
+In the Rust SDK `CapsFrame` is the **default response envelope** for
+NWP: `NwpClient::query` returns a `CapsFrame` directly (it reads
+`anchor_ref` + `payload`). Caps-advertisement usage and response usage
+share the same struct — differentiate by inspecting `caps` vs
+`payload`.
+
+---
+
+## `ErrorFrame` (0xFE)
+
+Unified protocol-level error.
+
+```rust
+pub struct ErrorFrame {
+    pub error_code: String,          // "NWP-QUERY-ANCHOR-UNKNOWN", …
+    pub message:    String,
+    pub detail:     Option<Value>,   // free-form extra context
+}
+```
+
+See [`error-codes.md`](https://github.com/labacacia/NPS-Release/blob/main/spec/error-codes.md)
+for the namespace.
+
+---
+
+## End-to-end
+
+```rust
+use nps_core::{FrameRegistry, NpsFrameCodec};
+use nps_core::cache::AnchorFrameCache;
+use nps_core::frames::{EncodingTier, FrameType};
+use nps_ncp::AnchorFrame;
+
+let codec = NpsFrameCodec::new(FrameRegistry::create_default());
+
+let mut schema = serde_json::Map::new();
+schema.insert("fields".into(), serde_json::json!([
+    { "name": "id", "type": "uint64" }
+]));
+
+let anchor_id = AnchorFrameCache::compute_anchor_id(&schema);
+let frame = AnchorFrame {
+    anchor_id, schema,
+    namespace: Some("example.products".into()),
+    description: Some("product catalog v1".into()),
+    node_type: Some("memory".into()),
+    ttl: 3600,
+};
+
+let wire = codec.encode(
+    AnchorFrame::frame_type(),
+    &frame.to_dict(),
+    EncodingTier::MsgPack,
+    /* is_final = */ true,
+)?;
+
+let (ft, dict) = codec.decode(&wire)?;
+assert_eq!(ft, FrameType::Anchor);
+let back = AnchorFrame::from_dict(&dict)?;
+assert_eq!(back.ttl, 3600);
+```

--- a/doc/nps-rust.ndp.md
+++ b/doc/nps-rust.ndp.md
@@ -1,0 +1,257 @@
+# `nps-ndp` — Reference
+
+> Spec: [NPS-4 NDP v0.2](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-4-NDP.md)
+
+Discovery layer — the NPS analogue of DNS. Three frames, an in-memory
+TTL registry, and a signature validator.
+
+---
+
+## Table of contents
+
+- [`AnnounceFrame` (0x30)](#announceframe-0x30)
+- [`ResolveFrame` (0x31)](#resolveframe-0x31)
+- [`GraphFrame` (0x32)](#graphframe-0x32)
+- [`InMemoryNdpRegistry`](#inmemoryndpregistry)
+- [`ResolveResult`](#resolveresult)
+- [`NdpAnnounceValidator`](#ndpannouncevalidator)
+- [`NdpAnnounceResult`](#ndpannounceresult)
+
+---
+
+## `AnnounceFrame` (0x30)
+
+Publishes a node's physical reachability and TTL (NPS-4 §3.1).
+
+```rust
+pub struct AnnounceFrame {
+    pub nid:       String,
+    pub addresses: Vec<serde_json::Map<String, Value>>,   // [{"host","port","protocol"}, …]
+    pub caps:      Vec<String>,
+    pub ttl:       u64,                                   // seconds; 0 = shutdown
+    pub timestamp: String,                                // ISO 8601 UTC
+    pub signature: String,                                // "ed25519:{base64}"
+    pub node_type: Option<String>,
+}
+
+impl AnnounceFrame {
+    pub fn unsigned_dict(&self) -> FrameDict;   // canonical (sorted) + signature stripped
+    pub fn to_dict(&self)       -> FrameDict;
+    pub fn from_dict(d: &FrameDict) -> NpsResult<Self>;
+}
+```
+
+`unsigned_dict()` in Rust already returns a sorted (`BTreeMap`-built)
+dict, so signing via `NipIdentity::sign` is a single call — no extra
+canonicalisation step. `from_dict` defaults `ttl` to `300` when absent.
+
+Publishing `ttl = 0` SHOULD precede a graceful shutdown so subscribers
+evict the entry promptly.
+
+---
+
+## `ResolveFrame` (0x31)
+
+Request / response envelope for resolving an `nwp://` URL.
+
+```rust
+pub struct ResolveFrame {
+    pub target:        String,                                    // "nwp://..."
+    pub requester_nid: Option<String>,
+    pub resolved:      Option<serde_json::Map<String, Value>>,    // set on response
+}
+```
+
+---
+
+## `GraphFrame` (0x32)
+
+Topology sync between registries.
+
+```rust
+pub struct GraphFrame {
+    pub seq:          u64,            // strictly monotonic per publisher
+    pub initial_sync: bool,           // full snapshot flag
+    pub nodes:        Vec<Value>,     // full dump when initial_sync = true
+    pub patch:        Option<Vec<Value>>,   // RFC 6902 ops for incremental sync
+}
+```
+
+Gaps in `seq` trigger a re-sync request signalled with
+`NDP-GRAPH-SEQ-GAP` (see [`error-codes.md`](https://github.com/labacacia/NPS-Release/blob/main/spec/error-codes.md)).
+
+---
+
+## `InMemoryNdpRegistry`
+
+In-memory, single-writer registry with TTL expiry evaluated **lazily**
+on every read.
+
+```rust
+pub struct InMemoryNdpRegistry {
+    pub clock: Box<dyn Fn() -> Instant + Send + Sync>,   // swap in tests
+    // …
+}
+
+impl InMemoryNdpRegistry {
+    pub fn new() -> Self;
+
+    pub fn announce(&mut self, frame: AnnounceFrame);
+
+    pub fn get_by_nid(&self, nid: &str) -> Option<&AnnounceFrame>;
+    pub fn resolve  (&self, target: &str) -> Option<ResolveResult>;
+    pub fn get_all  (&self) -> Vec<&AnnounceFrame>;
+
+    pub fn nwp_target_matches_nid(nid: &str, target: &str) -> bool;   // associated fn
+}
+```
+
+### Behaviour
+
+- `announce` with `ttl == 0` evicts the NID immediately. Otherwise the
+  entry is stored with an absolute expiry of `(clock)() + ttl seconds`
+  — subsequent announces refresh the entry in place.
+- `get_by_nid` / `resolve` / `get_all` skip expired entries without
+  mutating the store.
+- `resolve` scans live entries, finds the **first** NID that covers
+  `target`, and returns its **first** advertised address as
+  `ResolveResult`.
+
+### `nwp_target_matches_nid(nid, target)`
+
+Covering rule — associated function (no `&self`):
+
+```
+NID:    urn:nps:node:{authority}:{path}
+Target: nwp://{authority}/{path}[/sub/path]
+```
+
+A node NID covers a target when:
+
+1. `target` starts with `"nwp://"`.
+2. The NID authority equals the target authority (exact,
+   case-sensitive).
+3. The target path equals `{path}` exactly, or starts with `{path}/`
+   (sibling prefixes like `"data"` vs `"dataset"` do **not** match).
+
+Returns `false` on malformed inputs — never panics.
+
+### Injectable clock
+
+```rust
+use std::time::{Duration, Instant};
+
+let start = Instant::now();
+let mut reg = InMemoryNdpRegistry::new();
+reg.clock = Box::new(move || start + Duration::from_secs(86_400));  // skip a day ahead
+```
+
+---
+
+## `ResolveResult`
+
+```rust
+pub struct ResolveResult {
+    pub host:     String,
+    pub port:     u64,         // defaults to 17433 when missing from the address map
+    pub protocol: String,      // defaults to "nwp" when missing
+}
+```
+
+---
+
+## `NdpAnnounceValidator`
+
+Verifies an `AnnounceFrame.signature` against a registered Ed25519
+public key.
+
+```rust
+pub struct NdpAnnounceValidator { /* … */ }
+
+impl NdpAnnounceValidator {
+    pub fn new() -> Self;
+
+    pub fn register_public_key(&mut self, nid: impl Into<String>,
+                                           pub_key: impl Into<String>);
+    pub fn remove_public_key(&mut self, nid: &str);
+    pub fn known_public_keys(&self) -> &HashMap<String, String>;
+
+    pub fn validate(&self, frame: &AnnounceFrame) -> NdpAnnounceResult;
+}
+```
+
+Validation sequence (NPS-4 §7.1):
+
+1. Look up `frame.nid` in the registered keys. Missing →
+   `NdpAnnounceResult::fail("NDP-ANNOUNCE-NID-MISMATCH", …)`. Expected
+   workflow: verify the announcer's `IdentFrame` first, then
+   `register_public_key(nid, ident.pub_key)`.
+2. `signature` MUST start with `"ed25519:"`, else
+   `NDP-ANNOUNCE-SIG-INVALID`.
+3. Rebuild the signing payload from `frame.unsigned_dict()` (already
+   sorted) and call
+   [`NipIdentity::verify_with_pub_key_str`](./nps-rust.nip.md#nipidentity).
+4. Return `NdpAnnounceResult::ok()` on success, else
+   `NdpAnnounceResult::fail("NDP-ANNOUNCE-SIG-INVALID", …)`.
+
+Register keys using the exact string produced by
+`NipIdentity::pub_key_string()` — i.e. `"ed25519:{hex}"`.
+
+---
+
+## `NdpAnnounceResult`
+
+```rust
+pub struct NdpAnnounceResult {
+    pub is_valid:   bool,
+    pub error_code: Option<String>,
+    pub message:    Option<String>,
+}
+
+impl NdpAnnounceResult {
+    pub fn ok()                                    -> Self;
+    pub fn fail(code: impl Into<String>, msg: impl Into<String>) -> Self;
+}
+```
+
+---
+
+## End-to-end
+
+```rust
+use nps_nip::NipIdentity;
+use nps_ndp::{AnnounceFrame, InMemoryNdpRegistry, NdpAnnounceValidator};
+use serde_json::{json, Map};
+
+let id  = NipIdentity::generate();
+let nid = "urn:nps:node:api.example.com:products".to_string();
+
+// Build + sign the announce
+let mut addr = Map::new();
+addr.insert("host".into(),     json!("10.0.0.5"));
+addr.insert("port".into(),     json!(17433u16));
+addr.insert("protocol".into(), json!("nwp+tls"));
+
+let mut unsigned = AnnounceFrame {
+    nid:       nid.clone(),
+    addresses: vec![addr],
+    caps:      vec!["nwp:query".into(), "nwp:stream".into()],
+    ttl:       300,
+    timestamp: chrono::Utc::now().to_rfc3339(),
+    signature: String::new(),
+    node_type: Some("memory".into()),
+};
+unsigned.signature = id.sign(&unsigned.unsigned_dict());
+
+// Validate + register
+let mut validator = NdpAnnounceValidator::new();
+validator.register_public_key(nid.clone(), id.pub_key_string());
+let res = validator.validate(&unsigned);
+assert!(res.is_valid, "validation failed: {:?}", res);
+
+// Resolve
+let mut registry = InMemoryNdpRegistry::new();
+registry.announce(unsigned);
+let resolved = registry.resolve("nwp://api.example.com/products/items/42").unwrap();
+println!("{}:{} via {}", resolved.host, resolved.port, resolved.protocol);
+```

--- a/doc/nps-rust.nip.md
+++ b/doc/nps-rust.nip.md
@@ -1,0 +1,189 @@
+# `nps-nip` — Reference
+
+> Spec: [NPS-3 NIP v0.2](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-3-NIP.md)
+
+Identity layer. Three frames + an Ed25519 helper with
+AES-256-GCM-encrypted on-disk persistence.
+
+---
+
+## Table of contents
+
+- [`IdentFrame` (0x20)](#identframe-0x20)
+- [`TrustFrame` (0x21)](#trustframe-0x21)
+- [`RevokeFrame` (0x22)](#revokeframe-0x22)
+- [`NipIdentity`](#nipidentity)
+- [Key file format](#key-file-format)
+
+---
+
+## `IdentFrame` (0x20)
+
+Node identity declaration.
+
+```rust
+pub struct IdentFrame {
+    pub nid:       String,                            // "urn:nps:node:{authority}:{name}"
+    pub pub_key:   String,                            // "ed25519:{hex}"
+    pub meta:      Option<serde_json::Map<String, Value>>,
+    pub signature: Option<String>,                    // "ed25519:{base64}"
+}
+
+impl IdentFrame {
+    pub fn unsigned_dict(&self) -> FrameDict;   // strips `signature`
+    pub fn to_dict(&self)       -> FrameDict;
+    pub fn from_dict(d: &FrameDict) -> NpsResult<Self>;
+}
+```
+
+Signing workflow:
+
+1. Construct with `signature: None`.
+2. `identity.sign(&frame.unsigned_dict())` → `"ed25519:{base64}"`.
+3. Rebuild with `signature = Some(sig)` before encoding.
+
+---
+
+## `TrustFrame` (0x21)
+
+Delegation / trust assertion.
+
+```rust
+pub struct TrustFrame {
+    pub issuer_nid:  String,
+    pub subject_nid: String,
+    pub scopes:      Vec<String>,
+    pub expires_at:  Option<String>,   // ISO 8601 UTC
+    pub signature:   Option<String>,   // "ed25519:{base64}"
+}
+```
+
+Same signing convention: canonical-JSON of the dict minus the
+`signature` field.
+
+---
+
+## `RevokeFrame` (0x22)
+
+Revokes an NID — precede or accompany an `AnnounceFrame` with
+`ttl == 0`.
+
+```rust
+pub struct RevokeFrame {
+    pub nid:        String,
+    pub reason:     Option<String>,
+    pub revoked_at: Option<String>,
+}
+```
+
+---
+
+## `NipIdentity`
+
+Ed25519 keypair plus canonical-JSON sign / verify.
+
+```rust
+pub struct NipIdentity { /* … */ }
+
+impl NipIdentity {
+    pub fn generate() -> Self;
+
+    pub fn pub_key_string(&self) -> String;                // "ed25519:{hex}"
+
+    pub fn sign(&self, payload: &FrameDict) -> String;     // "ed25519:{base64}"
+    pub fn verify(&self, payload: &FrameDict, signature: &str) -> bool;
+
+    pub fn verify_with_key(&self, vk: VerifyingKey,
+                           payload: &FrameDict, signature: &str) -> bool;
+
+    /// Static: parse an "ed25519:{hex}" public key and verify against `payload`.
+    pub fn verify_with_pub_key_str(
+        payload: &FrameDict, pub_key: &str, signature: &str) -> bool;
+
+    pub fn save(&self, path: &Path, passphrase: &str) -> NpsResult<()>;
+    pub fn load(path: &Path, passphrase: &str)        -> NpsResult<Self>;
+}
+```
+
+### Canonical signing payload
+
+Both `sign` and the verify family serialise the payload through a
+`BTreeMap<String, Value>` (sorted-keys) via `serde_json::to_string` —
+no whitespace, lexical key order. This matches the sorted-keys
+canonicaliser shared with the .NET / Python / Java / TS SDKs;
+**RFC 8785 JCS is NOT used**.
+
+### Verification
+
+- `verify(&self, …)` verifies against the instance's own public key.
+- `verify_with_key` lets you supply a `VerifyingKey` for any third-party
+  key material.
+- `verify_with_pub_key_str` is the free-standing helper used by
+  [`NdpAnnounceValidator`](./nps-rust.ndp.md#ndpannouncevalidator) — it
+  parses `"ed25519:{hex}"` → 32-byte public key → verifies.
+
+All verify functions return `false` on any parsing, length, or signature
+mismatch error — they never panic.
+
+---
+
+## Key file format
+
+`save` writes an encrypted JSON envelope:
+
+```json
+{
+  "version":    1,
+  "algorithm":  "ed25519",
+  "pub_key":    "ed25519:<hex>",
+  "salt":       "<hex 16 bytes>",
+  "nonce":      "<hex 12 bytes>",
+  "ciphertext": "<hex — AES-256-GCM of the 32-byte seed>"
+}
+```
+
+| Parameter | Value |
+|-----------|-------|
+| PBKDF2 algorithm  | `PBKDF2-HMAC-SHA256` (`hmac::Hmac<Sha256>`) |
+| PBKDF2 iterations | 600 000 |
+| Derived key       | 32 bytes (256-bit) |
+| Salt              | 16 bytes (random, `OsRng`) |
+| Nonce             | 12 bytes (random, `OsRng`) |
+| Cipher            | `Aes256Gcm` (`aes-gcm` crate) |
+| Plaintext         | Raw Ed25519 seed — 32 bytes from `SigningKey::to_bytes()` |
+
+`load` recomputes the PBKDF2 key and decrypts; a wrong passphrase
+surfaces as `NpsError::Identity("decryption failed — wrong passphrase?")`.
+
+> **Cross-SDK note.** The Rust envelope stores the raw 32-byte Ed25519
+> seed. The Java SDK stores PKCS#8 / X.509 DER. The two formats are
+> **not** interchangeable byte-for-byte — use `pub_key_string()` +
+> `sign` output for cross-SDK interop instead of loading another SDK's
+> key file.
+
+---
+
+## End-to-end
+
+```rust
+use nps_nip::NipIdentity;
+use std::path::Path;
+
+let id   = NipIdentity::generate();
+let nid  = "urn:nps:node:api.example.com:products";
+
+// Sign a payload
+let mut payload = serde_json::Map::new();
+payload.insert("action".into(), serde_json::json!("announce"));
+payload.insert("nid".into(),    serde_json::json!(nid));
+let sig  = id.sign(&payload);
+assert!(id.verify(&payload, &sig));
+
+// Cross-key verification (e.g. via NDP announce validator)
+assert!(NipIdentity::verify_with_pub_key_str(&payload, &id.pub_key_string(), &sig));
+
+// Encrypted persistence
+id.save(Path::new("node.key"), "my-passphrase")?;
+let loaded = NipIdentity::load(Path::new("node.key"), "my-passphrase")?;
+assert_eq!(loaded.pub_key_string(), id.pub_key_string());
+```

--- a/doc/nps-rust.nop.md
+++ b/doc/nps-rust.nop.md
@@ -1,0 +1,285 @@
+# `nps-nop` — Reference
+
+> Spec: [NPS-5 NOP v0.3](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-5-NOP.md)
+
+Orchestration layer — DAG submission, fan-in barriers, streaming
+progress, async status polling.
+
+---
+
+## Table of contents
+
+- [`BackoffStrategy`](#backoffstrategy)
+- [`TaskState`](#taskstate)
+- [`NopTaskStatus`](#noptaskstatus)
+- [`TaskFrame` (0x40)](#taskframe-0x40)
+- [`DelegateFrame` (0x41)](#delegateframe-0x41)
+- [`SyncFrame` (0x42)](#syncframe-0x42)
+- [`AlignStreamFrame` (0x43)](#alignstreamframe-0x43)
+- [`NopClient`](#nopclient)
+
+---
+
+## `BackoffStrategy`
+
+```rust
+pub enum BackoffStrategy { Fixed, Linear, Exponential }
+
+impl BackoffStrategy {
+    pub fn compute_delay_ms(self, base_ms: u64, max_ms: u64, attempt: u32) -> u64;
+}
+```
+
+`compute_delay_ms` (0-indexed `attempt`):
+
+| Strategy       | Formula                  |
+|----------------|--------------------------|
+| `Fixed`        | `base_ms`                |
+| `Linear`       | `base_ms * (attempt + 1)`|
+| `Exponential`  | `base_ms * 2^attempt`    |
+
+Result is clamped at `max_ms`.
+
+---
+
+## `TaskState`
+
+```rust
+pub enum TaskState {
+    Pending,
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl TaskState {
+    pub fn from_str(s: &str) -> Option<Self>;   // case-sensitive: "pending" | "running" | …
+    pub fn is_terminal(self) -> bool;           // Completed | Failed | Cancelled
+}
+```
+
+> The Rust SDK exposes only the five common states above. Orchestrator
+> responses carrying `"preflight"`, `"waiting_sync"` or `"skipped"`
+> will decode with `state() == None` — use
+> `NopTaskStatus::raw()["state"]` to inspect the raw string when
+> needed.
+
+---
+
+## `NopTaskStatus`
+
+Thin view over the orchestrator's JSON status payload.
+
+```rust
+pub struct NopTaskStatus { /* raw: serde_json::Map<…, …> */ }
+
+impl NopTaskStatus {
+    pub fn from_dict(raw: serde_json::Map<String, Value>) -> Self;
+
+    pub fn task_id(&self)       -> &str;
+    pub fn state(&self)         -> Option<TaskState>;
+    pub fn is_terminal(&self)   -> bool;
+    pub fn error_code(&self)    -> Option<&str>;
+    pub fn error_message(&self) -> Option<&str>;
+    pub fn node_results(&self)  -> Option<&serde_json::Map<String, Value>>;
+    pub fn raw(&self)           -> &serde_json::Map<String, Value>;
+}
+
+impl Display for NopTaskStatus { /* "NopTaskStatus(task_id=…, state=…)" */ }
+```
+
+Use `raw()` to reach orchestrator-specific fields that the typed
+accessors don't cover.
+
+---
+
+## `TaskFrame` (0x40)
+
+Submit a DAG for execution. The DAG itself is kept as a free-form
+`serde_json::Value` that matches the NPS-5 wire shape
+(`{"nodes": [...], "edges": [...]}`).
+
+```rust
+pub struct TaskFrame {
+    pub task_id:      String,
+    pub dag:          Value,               // free-form DAG JSON
+    pub timeout_ms:   Option<u64>,
+    pub callback_url: Option<String>,      // SSRF-validated by orchestrator
+    pub context:      Option<Value>,       // { "session_key", "requester_nid", "trace_id" }
+    pub priority:     Option<String>,      // "low" | "normal" | "high"
+    pub depth:        Option<i64>,         // delegate chain depth, max 3
+}
+```
+
+Spec limits the orchestrator enforces (NPS-5 §8.2): max 32 nodes per
+DAG, max 3 levels of delegate chain, max timeout 3 600 000 ms (1 h).
+
+---
+
+## `DelegateFrame` (0x41)
+
+Per-node invocation emitted by the orchestrator to each agent.
+
+```rust
+pub struct DelegateFrame {
+    pub task_id:         String,
+    pub subtask_id:      String,
+    pub action:          String,
+    pub target_nid:      String,
+    pub inputs:          Option<Value>,
+    pub config:          Option<Value>,
+    pub idempotency_key: Option<String>,
+}
+```
+
+> Field naming differs from other SDKs: the Rust SDK uses
+> `target_nid` + `config` where the .NET / Python / Java SDKs use
+> `agent_nid` + `params`. Wire payloads follow the field names above.
+
+---
+
+## `SyncFrame` (0x42)
+
+Fan-in barrier — waits for K-of-N upstream subtasks.
+
+```rust
+pub struct SyncFrame {
+    pub task_id:      String,
+    pub sync_id:      String,
+    pub subtask_ids:  Vec<String>,
+    pub min_required: i64,               // 0 = strict all-of
+    pub aggregate:    String,            // "merge" | "first" | "fastest_k" | "all"
+    pub timeout_ms:   Option<u64>,
+}
+```
+
+`from_dict` defaults `min_required` to `0` and `aggregate` to
+`"merge"` when those fields are missing.
+
+`min_required` semantics:
+
+| Value | Meaning |
+|-------|---------|
+| `0`   | Wait for all of `subtask_ids` (strict fan-in). |
+| `K`   | Proceed as soon as K upstream subtasks have completed. |
+
+---
+
+## `AlignStreamFrame` (0x43)
+
+Streaming progress / partial result frame for a delegated subtask.
+
+```rust
+pub struct AlignStreamFrame {
+    pub sync_id:     String,
+    pub task_id:     String,
+    pub subtask_id:  String,
+    pub seq:         u64,
+    pub is_final:    bool,
+    pub source_nid:  Option<String>,
+    pub result:      Option<Value>,       // opaque payload
+    pub error:       Option<Value>,       // { "error_code", "message" }
+    pub window_size: Option<u64>,
+}
+
+impl AlignStreamFrame {
+    pub fn error_code(&self)    -> Option<&str>;   // shortcut for error["error_code"]
+    pub fn error_message(&self) -> Option<&str>;   // shortcut for error["message"]
+}
+```
+
+`AlignStreamFrame` replaces the deprecated `AlignFrame (0x05)` — it
+carries task context (`task_id` + `subtask_id` + `sync_id`) and binds
+the stream to a `source_nid`.
+
+---
+
+## `NopClient`
+
+Async HTTP client for an NOP orchestrator.
+
+```rust
+pub struct NopClient { /* … */ }
+
+impl NopClient {
+    pub fn new(base_url: impl Into<String>) -> Self;
+
+    pub async fn submit    (&self, frame: &TaskFrame) -> NpsResult<String>;    // → task_id
+    pub async fn get_status(&self, task_id: &str)     -> NpsResult<NopTaskStatus>;
+    pub async fn cancel    (&self, task_id: &str)     -> NpsResult<()>;
+
+    pub async fn wait(
+        &self,
+        task_id:       &str,
+        timeout:       std::time::Duration,
+        poll_interval: std::time::Duration,
+    ) -> NpsResult<NopTaskStatus>;
+}
+```
+
+### HTTP routes
+
+| Method       | Path               | Request body                      | Response |
+|--------------|--------------------|-----------------------------------|----------|
+| `submit`     | `POST   /tasks`    | JSON of `TaskFrame::to_dict()`    | JSON `{ "task_id": … }` |
+| `get_status` | `GET    /tasks/{}` | —                                 | JSON status dict |
+| `cancel`     | `DELETE /tasks/{}` | —                                 | — |
+| `wait`       | polls `get_status` until terminal or `timeout`; `tokio::time::sleep` between polls |
+
+Requests use `Content-Type: application/json` — the Rust NOP client
+submits the task dict as plain JSON, not as a framed
+`application/x-nps-frame` payload.
+
+`wait` fails with `NpsError::Io("timeout waiting for task …")` if the
+deadline elapses before the task reaches a terminal state; it returns
+the terminal `NopTaskStatus` on success.
+
+### Errors
+
+- Non-2xx HTTP → `NpsError::Io("NOP {path} failed: HTTP {status}")`.
+- Missing `task_id` in the submit response → `NpsError::Frame`.
+- Transport / decode failures → `NpsError::Io` / `NpsError::Codec`.
+
+---
+
+## End-to-end
+
+```rust
+use nps_nop::{NopClient, TaskFrame, BackoffStrategy};
+use serde_json::json;
+use std::time::Duration;
+
+let dag = json!({
+    "nodes": [
+        { "id": "fetch",    "action": "fetch",
+          "agent": "urn:nps:node:ingest.example.com:http" },
+        { "id": "classify", "action": "classify",
+          "agent": "urn:nps:node:ml.example.com:classifier",
+          "input_from": ["fetch"],
+          "retry_policy": {
+              "max_retries":   3,
+              "backoff":       "exponential",
+              "base_delay_ms": 500
+          }}
+    ],
+    "edges": [ { "from": "fetch", "to": "classify" } ]
+});
+
+let nop = NopClient::new("http://orchestrator.example.com:17433");
+let tid = nop.submit(&TaskFrame {
+    task_id:      "job-42".into(),
+    dag,
+    timeout_ms:   Some(60_000),
+    callback_url: None,
+    context:      None,
+    priority:     Some("normal".into()),
+    depth:        None,
+}).await?;
+
+let status = nop.wait(&tid, Duration::from_secs(60), Duration::from_millis(500)).await?;
+println!("{status}");
+
+// Backoff computation
+let delay = BackoffStrategy::Exponential.compute_delay_ms(500, 30_000, 2);  // → 2000
+```

--- a/doc/nps-rust.nwp.md
+++ b/doc/nps-rust.nwp.md
@@ -1,0 +1,203 @@
+# `nps-nwp` — Reference
+
+> Spec: [NPS-2 NWP v0.4](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-2-NWP.md)
+
+Agent-facing HTTP layer. Two frame types, one async client built on
+`reqwest`.
+
+---
+
+## Table of contents
+
+- [`QueryFrame` (0x10)](#queryframe-0x10)
+- [`ActionFrame` (0x11)](#actionframe-0x11)
+- [`AsyncActionResponse`](#asyncactionresponse)
+- [`NwpClient`](#nwpclient)
+- [`InvokeResult`](#invokeresult)
+
+---
+
+## `QueryFrame` (0x10)
+
+Paginated / filtered query against a Memory Node.
+
+```rust
+pub struct QueryFrame {
+    pub anchor_ref:   String,                // required
+    pub filter:       Option<Value>,         // NPS-2 §4 filter DSL (free-form JSON)
+    pub order:        Option<Value>,         // e.g. [{"field":"id","dir":"asc"}]
+    pub token_budget: Option<u64>,           // NPT Budget cap (NPS Token Budget spec)
+    pub limit:        Option<u64>,
+    pub offset:       Option<u64>,
+}
+
+impl QueryFrame {
+    pub fn new(anchor_ref: impl Into<String>) -> Self;   // all other fields = None
+    pub fn frame_type() -> FrameType;                    // FrameType::Query
+    pub fn to_dict(&self)   -> FrameDict;
+    pub fn from_dict(d: &FrameDict) -> NpsResult<Self>;
+}
+```
+
+`anchor_ref` is non-optional. The Rust `QueryFrame` does not carry the
+`vector_search` / `fields` / `depth` fields of the Java / Python / TS
+SDKs — use `filter`/`order` for the equivalent logic and advertise the
+vector-search dialect in the anchor schema.
+
+---
+
+## `ActionFrame` (0x11)
+
+Invoke an action on a node.
+
+```rust
+pub struct ActionFrame {
+    pub action:     String,
+    pub params:     Option<Value>,
+    pub anchor_ref: Option<String>,
+    pub async_:     bool,              // serialises to "async" on the wire
+}
+```
+
+The field is spelt `async_` in Rust because `async` is a reserved
+keyword; `to_dict` / `from_dict` translate to and from the `"async"`
+JSON key.
+
+`idempotency_key` / `timeout_ms` are not modelled as struct fields —
+attach them via `params` if the remote action supports them.
+
+---
+
+## `AsyncActionResponse`
+
+Returned by `NwpClient::invoke` when the request frame has
+`async_ == true` (wrapped in `InvokeResult::Async`).
+
+```rust
+pub struct AsyncActionResponse {
+    pub task_id:      String,
+    pub status_url:   Option<String>,
+    pub callback_url: Option<String>,
+}
+
+impl AsyncActionResponse {
+    pub fn from_dict(d: &FrameDict) -> NpsResult<Self>;
+}
+```
+
+Poll `status_url` or hand `task_id` to
+[`NopClient::wait`](./nps-rust.nop.md#nopclient) to reach a terminal
+state.
+
+---
+
+## `NwpClient`
+
+Async HTTP client.
+
+```rust
+pub struct NwpClient { /* … */ }
+
+impl NwpClient {
+    pub fn new(base_url: impl Into<String>) -> Self;
+    pub fn with_tier(self, tier: EncodingTier) -> Self;       // builder
+
+    pub async fn send_anchor(&self, frame: &AnchorFrame) -> NpsResult<()>;
+    pub async fn query      (&self, frame: &QueryFrame)  -> NpsResult<CapsFrame>;
+    pub async fn stream     (&self, frame: &QueryFrame)  -> NpsResult<Vec<StreamFrame>>;
+    pub async fn invoke     (&self, frame: &ActionFrame) -> NpsResult<InvokeResult>;
+}
+```
+
+### Defaults
+
+- Trailing `/` is stripped from `base_url`; every call POSTs to
+  `{base_url}/{route}`.
+- Default `tier = EncodingTier::MsgPack`. Override with `with_tier`.
+- Internal codec uses `FrameRegistry::create_full()` — queries and
+  actions can reach nodes that respond with NCP, NIP, NDP or NOP
+  frames.
+- Injected HTTP client is `reqwest::Client::new()` — configure TLS /
+  timeouts by patching the struct (`client.http = …`) in consumer
+  code, or wrap your own transport.
+
+### HTTP routes
+
+| Method        | Path      | Request body                 | Response body |
+|---------------|-----------|------------------------------|---------------|
+| `send_anchor` | `/anchor` | encoded `AnchorFrame`        | — (2xx only) |
+| `query`       | `/query`  | encoded `QueryFrame`         | encoded `CapsFrame` |
+| `stream`      | `/stream` | encoded `QueryFrame`         | concatenated `StreamFrame`s |
+| `invoke`      | `/invoke` | encoded `ActionFrame`        | encoded frame, JSON (async), or fallback JSON |
+
+Request headers: `Content-Type: application/x-nps-frame`, `Accept:
+application/x-nps-frame`.
+
+### `stream` behaviour
+
+Buffered: the response body is read into a `Vec<u8>`, then sliced
+frame-by-frame via `FrameHeader::parse`. Iteration stops when a frame
+reports `is_last == true` (the in-payload flag — not the wire FINAL
+bit).
+
+### `invoke` dispatch
+
+| Request | Response Content-Type | Returned variant |
+|---------|-----------------------|------------------|
+| `async_ == true` | any | `InvokeResult::Async(AsyncActionResponse)` — body parsed as JSON |
+| `async_ == false` | contains `application/x-nps-frame` | `InvokeResult::Frame(FrameDict)` — body decoded via codec |
+| `async_ == false` | anything else | `InvokeResult::Json(FrameDict)` — body parsed as JSON |
+
+### Errors
+
+- Non-2xx HTTP → `NpsError::Io("NWP /{path} failed: HTTP {status}")`.
+- Transport / TLS failure → `NpsError::Io(e.to_string())`.
+- Payload decode failure → `NpsError::Codec`.
+- Unexpected frame type (e.g. `query` returns non-Caps) →
+  `NpsError::Frame`.
+
+---
+
+## `InvokeResult`
+
+```rust
+pub enum InvokeResult {
+    Frame(FrameDict),              // NPS-encoded response, already decoded to dict
+    Async(AsyncActionResponse),    // 202-style async handle
+    Json(FrameDict),               // JSON response (non-NPS content-type)
+}
+```
+
+Pattern-match on the variant; if you need a typed NCP frame from
+`Frame(dict)` call `CapsFrame::from_dict(&dict)` / `ErrorFrame::from_dict(&dict)`
+etc.
+
+---
+
+## End-to-end
+
+```rust
+use nps_nwp::{NwpClient, QueryFrame, ActionFrame, InvokeResult};
+
+let client = NwpClient::new("http://node.example.com:17433");
+
+// Query
+let mut q = QueryFrame::new("sha256:abc123");
+q.filter = Some(serde_json::json!({ "active": true }));
+q.limit  = Some(50);
+let caps = client.query(&q).await?;
+println!("caps: {:?}", caps.caps);
+
+// Invoke
+let action = ActionFrame {
+    action:     "summarise".into(),
+    params:     Some(serde_json::json!({ "max_tokens": 500 })),
+    anchor_ref: None,
+    async_:     false,
+};
+match client.invoke(&action).await? {
+    InvokeResult::Frame(dict) => { /* decoded NPS frame */ }
+    InvokeResult::Async(r)    => { /* poll NopClient::wait(&r.task_id, …) */ }
+    InvokeResult::Json(dict)  => { /* plain JSON fallback */ }
+}
+```

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -1,0 +1,149 @@
+# NPS Rust SDK — API Reference
+
+> Async Rust SDK for the Neural Protocol Suite — Rust stable (1.75+), Tokio-based.
+
+This directory is the class-and-method reference for `nps-sdk`. For a
+narrative quick-start and end-to-end examples see
+[`sdk-usage.md`](./sdk-usage.md) (English) or
+[`sdk-usage.cn.md`](./sdk-usage.cn.md) (中文). For the bundled CA server
+see [`ca-server.md`](./ca-server.md).
+
+---
+
+## Workspace crates
+
+| Crate | Purpose | Reference |
+|-------|---------|-----------|
+| `nps-core` | Frame header, codec (Tier-1 JSON / Tier-2 MsgPack), frame registry, anchor cache, errors | [`nps-rust.core.md`](./nps-rust.core.md) |
+| `nps-ncp`  | NCP frames — `AnchorFrame`, `DiffFrame`, `StreamFrame`, `CapsFrame`, `ErrorFrame` | [`nps-rust.ncp.md`](./nps-rust.ncp.md) |
+| `nps-nwp`  | NWP frames + async `NwpClient` (reqwest) | [`nps-rust.nwp.md`](./nps-rust.nwp.md) |
+| `nps-nip`  | NIP frames + `NipIdentity` (Ed25519, AES-256-GCM key store) | [`nps-rust.nip.md`](./nps-rust.nip.md) |
+| `nps-ndp`  | NDP frames, `InMemoryNdpRegistry`, `NdpAnnounceValidator` | [`nps-rust.ndp.md`](./nps-rust.ndp.md) |
+| `nps-nop`  | NOP frames, `BackoffStrategy`, `NopTaskStatus`, async `NopClient` | [`nps-rust.nop.md`](./nps-rust.nop.md) |
+| `nps-sdk`  | Meta-crate — re-exports everything under `nps_sdk::{core, ncp, nwp, nip, ndp, nop}` | (façade — re-exports only) |
+
+---
+
+## Install
+
+`Cargo.toml`:
+
+```toml
+[dependencies]
+nps-sdk = "1.0.0-alpha.1"                             # full façade
+# — or pick individual crates:
+nps-core = "1.0.0-alpha.1"
+nps-ncp  = "1.0.0-alpha.1"
+nps-nwp  = "1.0.0-alpha.1"
+nps-nip  = "1.0.0-alpha.1"
+nps-ndp  = "1.0.0-alpha.1"
+nps-nop  = "1.0.0-alpha.1"
+tokio    = { version = "1", features = ["full"] }     # required for nwp/nop async clients
+```
+
+`nps-sdk` re-exports the protocol crates behind feature flags (`nwp`,
+`nip`, `ndp`, `nop`); `core` + `ncp` are always re-exported.
+
+---
+
+## Minimal encode / decode
+
+```rust
+use nps_core::{FrameRegistry, NpsFrameCodec};
+use nps_core::frames::{EncodingTier, FrameType};
+use nps_ncp::AnchorFrame;
+
+let codec = NpsFrameCodec::new(FrameRegistry::create_full());
+
+let mut schema = serde_json::Map::new();
+schema.insert("fields".into(), serde_json::json!([
+    { "name": "id",    "type": "uint64"  },
+    { "name": "price", "type": "decimal" },
+]));
+let frame = AnchorFrame {
+    anchor_id:   "sha256:abc123".into(),
+    schema,
+    namespace:   None,
+    description: None,
+    node_type:   None,
+    ttl:         3600,
+};
+
+let wire = codec.encode(
+    AnchorFrame::frame_type(),
+    &frame.to_dict(),
+    EncodingTier::MsgPack,
+    /* is_final = */ true,
+)?;
+
+let (ft, dict) = codec.decode(&wire)?;
+assert_eq!(ft, FrameType::Anchor);
+let back = AnchorFrame::from_dict(&dict)?;
+```
+
+The codec is dict-oriented: there is no typed `encode<T: NpsFrame>`
+method. Each frame type exposes `frame_type()`, `to_dict()` and
+`from_dict()` — call them explicitly around `codec.encode` /
+`codec.decode`.
+
+---
+
+## Encoding tiers
+
+| Tier | `EncodingTier` | Wire flag (bit 7) | Notes |
+|------|----------------|-------------------|-------|
+| Tier-1 JSON    | `EncodingTier::Json`    | `0` | UTF-8 JSON, debug / interop |
+| Tier-2 MsgPack | `EncodingTier::MsgPack` | `1` | `rmp-serde` (`to_vec_named`), production default |
+
+**Rust flag byte layout** (differs from the Java / Python / .NET SDKs):
+
+| Bit | Mask   | Meaning |
+|-----|--------|---------|
+| 7   | `0x80` | TIER — `1` = MsgPack, `0` = JSON |
+| 6   | `0x40` | FINAL — last frame in a stream |
+| 0   | `0x01` | EXT — 8-byte extended header (payload > 65 535 bytes) |
+
+Header sizes: 4 bytes default, 8 bytes when `EXT = 1`
+(`[type][flags][0][0][len_b3..len_b0]`). Max payload defaults to 10 MiB
+(`nps_core::codec::DEFAULT_MAX_PAYLOAD`) — raise with
+`NpsFrameCodec::new(r).with_max_payload(n)`.
+
+---
+
+## Async I/O
+
+- `NwpClient` (`nps-nwp`) and `NopClient` (`nps-nop`) are `async` and
+  require a Tokio runtime.
+- All fallible operations return `NpsResult<T>` = `Result<T, NpsError>`.
+- Non-2xx HTTP responses surface as `NpsError::Io("NWP /{path} failed: HTTP …")`
+  — not panics.
+
+---
+
+## Error type
+
+`NpsError` (from `nps-core`):
+
+| Variant | Raised by |
+|---------|-----------|
+| `Frame(String)`          | Unknown frame type / missing fields / type mismatches |
+| `Codec(String)`          | JSON or MsgPack encode / decode failure, payload oversized |
+| `AnchorNotFound(String)` | `AnchorFrameCache::get_required` on missing / expired anchor |
+| `AnchorPoison(String)`   | `AnchorFrameCache::set` with schema mismatch for same `anchor_id` |
+| `Identity(String)`       | Key gen / save / load / PBKDF2 / AES-GCM failure |
+| `Io(String)`             | `reqwest` network error, non-2xx HTTP, file I/O |
+
+All variants implement `Display` and `std::error::Error`.
+
+---
+
+## Spec links
+
+- [NPS-0 Overview](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-0-Overview.md)
+- [NPS-1 NCP](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-1-NCP.md)
+- [NPS-2 NWP](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-2-NWP.md)
+- [NPS-3 NIP](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-3-NIP.md)
+- [NPS-4 NDP](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-4-NDP.md)
+- [NPS-5 NOP](https://github.com/labacacia/NPS-Release/blob/main/spec/NPS-5-NOP.md)
+- [Frame registry](https://github.com/labacacia/NPS-Release/blob/main/spec/frame-registry.yaml)
+- [Error codes](https://github.com/labacacia/NPS-Release/blob/main/spec/error-codes.md)


### PR DESCRIPTION
## Summary
- New class-and-method reference for every workspace crate: `doc/overview.md` + `doc/nps-rust.{core,ncp,nwp,nip,ndp,nop}.md`
- Existing `doc/sdk-usage.*.md` + `doc/ca-server.md` are preserved; the new reference sits alongside them
- README Crates table gains a Reference column pointing at the new per-crate docs

## Notes
- Rust-specific flag-byte layout (`0x80` TIER / `0x40` FINAL / `0x01` EXT) is called out in the overview + core docs
- NCP frame-shape differences from the Java / Python / TS / .NET SDKs are documented faithfully (AnchorFrame extras, CapsFrame as response envelope, DiffFrame `new_anchor_id`, StreamFrame `is_last`, ErrorFrame `detail`)
- NOP field renames (`target_nid`/`config`, `sync_id`, `source_nid`/`result`, `subtask_ids`) are flagged where they diverge from other SDKs

## Test plan
- [ ] Verify all doc links render correctly on GitHub
- [ ] Spot-check signatures against the current source in `nps-core/`, `nps-ncp/`, `nps-nwp/`, `nps-nip/`, `nps-ndp/`, `nps-nop/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)